### PR TITLE
Docker demo - make "demo-ready" images from existing theia-based images

### DIFF
--- a/.github/workflows/docker-example.yml
+++ b/.github/workflows/docker-example.yml
@@ -1,4 +1,4 @@
-name: docker-example
+name: docker-examples
 
 on:
   push:
@@ -9,19 +9,19 @@ on:
 jobs:
 
   build-and-test:
-    name: Build and test docker-example
+    name: build and test images
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        node-version: [18]
         params:
           - name: "tate"
             resources-folder: "theia-app-theia-ext"
           - name: "tave"
             resources-folder: "theia-app-vscode-ext"
+        os: [ubuntu-latest]
+        node-version: [18]
 
     steps:
     - uses: actions/checkout@v4
@@ -31,7 +31,12 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: Build example app
+    - name: Install npm dependencies
+      run: |
+        cd docker
+        yarn --ignore-scripts
+
+    - name: Build trace viewer image (base version)
       uses: nick-invision/retry@v3
       with:
         timeout_minutes: 10
@@ -40,16 +45,38 @@ jobs:
         retry_on: error
         command: |
           cd docker
-          docker build . --build-arg RESOURCES=${{ matrix.params.resources-folder }} -t tv-${{ matrix.params.name }} -f Dockerfile-${{ matrix.params.name }} 
-        on_retry_command: cd ../..
+          yarn build:docker:${{ matrix.params.name }}
+        on_retry_command: cd ..
 
-    - name: Run docker image
+    - name: Run trace viewer image (base version)
       run: |
-        docker run --init -d -p 0.0.0.0:3000:4000 tv-${{ matrix.params.name }}
+        cd docker
+        docker run --init -d -p 0.0.0.0:3000:4000 --name tv-${{ matrix.params.name }}-1 tv-${{ matrix.params.name }}
 
-    - name: Test trace viewer appliance
+    - name: Test trace viewer (base version)
       run: |
-        yarn --ignore-scripts
         cd docker
         yarn --cwd ${{ matrix.params.resources-folder }} test
+        docker kill tv-${{ matrix.params.name }}-1
 
+    - name: Build trace viewer image (demo version)
+      uses: nick-invision/retry@v3
+      with:
+        timeout_minutes: 10
+        retry_wait_seconds: 15
+        max_attempts: 1
+        retry_on: error
+        command: |
+          cd docker
+          yarn build:docker:${{ matrix.params.name }}-demo
+        on_retry_command: cd ..
+
+    - name: Run trace viewer image (demo version)
+      run: |
+        docker run --init -d -p 0.0.0.0:3000:4000 --name tv-${{ matrix.params.name }}-demo-1 tv-${{ matrix.params.name }}-demo
+        
+    - name: Test trace viewer (demo version)
+      run: |
+        cd docker
+        yarn --cwd ${{ matrix.params.resources-folder }} test-demo
+        docker kill tv-${{ matrix.params.name }}-demo-1

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,5 +4,5 @@ If you think or suspect that you have discovered a new security vulnerability in
 
 Instead, please report any potential vulnerability to the Eclipse Foundation [Security Team][security]. Make sure to provide a concise description of the issue, a CWE, and other supporting information.
 
-[policy]: https://www.eclipse.org/security/policy.php
+[policy]: https://www.eclipse.org/security/policy/
 [security]: https://www.eclipse.org/security

--- a/docker/Dockerfile-demo
+++ b/docker/Dockerfile-demo
@@ -1,0 +1,36 @@
+# How to use: pass as an "app" build argument, the name of the base 
+# trace-viewer image to extend. e.g.:
+#   $ docker build --build-arg app=tv-tate --network=host . --build-arg RESOURCES=theia-app-demo -t tv-tate-demo -f Dockerfile-demo
+#
+# Layout of the resulting demo image:
+#
+# trace viewer application (unchanged): /app/tv
+# Trace Server folder: /app/trace-compass-server
+# Trace server executable: /app/trace-compass-server/tracecompass-server
+# Tutorial traces folder: : /workspaces/TraceCompassTutorialTraces/
+# Default workspace: /workspaces/TraceCompassTutorialTraces/
+
+ARG app
+
+FROM ${app}
+ARG RESOURCES
+
+# needed by the trace server
+RUN apt-get update && apt-get install -y \
+    openjdk-17-jdk \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspaces
+# contains scripts entries to download trace server and sample traces
+COPY package.json /workspaces
+RUN yarn download:sample-traces
+RUN yarn download:server && mv trace-compass-server /app/
+# not needed anymore
+RUN rm package.json 
+
+COPY ${RESOURCES}/docker-entrypoint-w-server.sh /usr/local/bin
+WORKDIR /app/tv
+
+EXPOSE 4000
+ENTRYPOINT ["docker-entrypoint-w-server.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,10 +6,12 @@ Each application has a `DockerFile` in this folder and its resources in a sub-fo
 
 - `DockerFile-tate, resources folder: theia-app-theia-ext/`: Dockerfile and resourced needed to build a Trace Viewer Appliance, using a Theia application that includes the _Theia Trace Viewer_ _(Theia) extension_, installed [from npm][npm package].
 - `DockerFile-tave, resources folder: theia-app-vscode-ext/`: Dockerfile and resources needed to build a Trace Viewer Appliance, using a Theia application that includes the _Trace Viewer for VSCode_ _(vsix) extension_, installed [from the open vsx public registry][vsix package]
+- `Dockerfile-demo, resources folder: theia-app-demo/`: Dockerfile that extends one of the Theia-based docker image (tate, tave) and makes it "demo-ready" by adding the Eclipse Trace Compass trace server, a set of sample traces and configuring the traces folder as the starting workspace. See corresponding [README](theia-app-demo/README.md) for more details.
 
 Note:
 
-- the images will contain exclusively the trace viewer front-end. If you want to run a complete _trace viewer_ application, you will need a service running the trace-server (not included here)
+- the `-demo` images are meant to be "up-and-running" quickly and contain a trace server and some Tutorial traces. For some quick tests or a demo, this is perfect, but maybe not suitable for general use, where you probably want to view your own traces.
+- the other images contain exclusively the trace viewer front-end. If you want to run a complete _trace viewer_ application, you will need a service running the trace-server (not included here)
 - see section "Docker tips and tricks" if you are relatively new to Docker and want to learn about some potential alternatives or refinements about some of the commands in this document.
 
 ## Quickly Build/Run the example Docker images
@@ -126,7 +128,7 @@ $ yarn && yarn build
 $ yarn && yarn build:prod
 ```
 
-If after the build, it turns-out that `yarn.lock` has been modified, the new version needs to be upstreamed as part of the PR that changed the Theia application.
+If after the build, it turns-out that `yarn.lock` has been modified, the new version needs to be upstreamed as part of the PR that changed the Theia application, so that the applications built as part of the images will use the same dependencies/versions.
 
 ## Docker tips and tricks
 

--- a/docker/package.json
+++ b/docker/package.json
@@ -15,9 +15,16 @@
     "tave": "yarn --cwd theia-app-vscode-ext",
     "build:docker": "yarn build:docker:tate && yarn build:docker:tave",
     "build:docker:tate": "docker build  --no-cache --network=host . --build-arg RESOURCES=theia-app-theia-ext -t tv-tate -f Dockerfile-tate",
+    "build:docker:tate-demo": "docker build --build-arg app=tv-tate --no-cache --network=host . --build-arg RESOURCES=theia-app-demo -t tv-tate-demo -f Dockerfile-demo",
+    "build:docker:tave-demo": "docker build --build-arg app=tv-tave --no-cache --network=host . --build-arg RESOURCES=theia-app-demo -t tv-tave-demo -f Dockerfile-demo",
     "build:docker:tave": "docker build  --no-cache --network=host . --build-arg RESOURCES=theia-app-vscode-ext -t tv-tave -f Dockerfile-tave",
     "run:docker:tate": "docker run --rm --name tv-tate-1 --network host tv-tate",
-    "run:docker:tave": "docker run --rm --name tv-tave-1 --network host tv-tave"
+    "run:docker:tate-demo": "docker run --rm --name tv-tate-demo-1 tv-tate-demo",
+    "run:docker:tave": "docker run --rm --name tv-tave-1 --network host tv-tave",
+    "run:docker:tave-demo": "docker run --network host --rm --name tv-tave-demo-1 tv-tave-demo",
+    "download:sample-traces": "curl -o TraceCompassTutorialTraces.tgz https://raw.githubusercontent.com/tuxology/tracevizlab/master/labs/TraceCompassTutorialTraces.tgz; tar -xf TraceCompassTutorialTraces.tgz; rm TraceCompassTutorialTraces.tgz",
+    "download:server": "curl -o trace-compass-server.tar.gz https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/trace-compass-server-latest-linux.gtk.x86_64.tar.gz; tar -xf trace-compass-server.tar.gz; rm trace-compass-server.tar.gz",
+    "start:server": "./trace-compass-server/tracecompass-server"
   },
   "engines": {
   },

--- a/docker/theia-app-demo/README.md
+++ b/docker/theia-app-demo/README.md
@@ -1,0 +1,65 @@
+# Resources for the "theia-app-demo" Example docker image
+
+This folder contains the resources, needed to create a "demo" Docker image, based on one of the Theia app images. The demo image includes the necessary extras to easily perform a quick demo or immediately play with the trace viewer: the Eclipse Trace Compass Trace Server and a selection of Tutorial traces.
+
+## Build the demo images
+
+After connecting to either the tate or tave application using a browser, following the instructions below, the app should open with the trace server running and the workspace already selected, containing the tutorial traces, ready to use.
+
+Run the following commands from the parent folder (\<repo root\>/docker):
+
+```bash
+# e.g. make "tate" / "tave" demo image(s)
+
+# pre-requisite: the base image(s) need to be already built locally. 
+# If not, or it they are not up-to-date, start by (re)building them:
+yarn build:docker:tate
+yarn build:docker:tave
+
+# make the demo image(s) that extend the base image(s)
+yarn build:docker:tate-demo
+yarn build:docker:tave-demo
+```
+
+## Run the demo images
+
+### tate-demo (isolated docker network)
+
+Note: since the isolated docker network is used, you may start several containers from the tate-demo image and each one will have its own, indepandant trace server.
+
+Run the following commands from the parent folder (\<repo root\>/docker):
+
+```bash
+# start the demo image
+yarn run:docker:tate-demo
+
+# using the start script above, the image is deployed isolated
+# find its IP address:
+docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' tv-tate-demo-1
+100.109.0.1
+
+# connect to it (replace with the ip address you obtained in the
+# previous step):
+firefox 100.109.0.1:4000
+```
+
+### tave-demo (host network)
+
+The trace viewer contained in the "tave" image uses vscode webviews. For security reasons, these webviews, by default, only work with SSL (HTTPS) and some extra network setup \[*\]. There is however an exception made for running the app on the localhost network, that's considered "safe" by default. It's beyond the scope of this guide to go into these details, so we will provide instructions to run that image using the host network, which should work OOTB locally and still be safe.
+
+\[*\]: for more info start here:
+https://github.com/eclipse-theia/theia/blob/86267992e133b3ee59508d4e2afbcfc6e384d61c/packages/plugin-ext/README.md
+
+Note: because the image's trace server uses the host's network, it might interfere or be interfered-with, by a trace server running locally on the host or in another container running the same image. To avoid issues, kill any trace server running locally on the host before starting this demo image and kill the container before starting a local trace server.
+
+Run the following commands from the parent folder (\<repo root\>/docker):
+
+```bash
+# start the demo image
+yarn run:docker:tave-demo
+
+# ***tave-demo***:
+# using the start script above, the image is deployed using the 
+# docker host network. 
+firefox localhost:4000
+```

--- a/docker/theia-app-demo/docker-entrypoint-w-server.sh
+++ b/docker/theia-app-demo/docker-entrypoint-w-server.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# start trace server
+/app/trace-compass-server/tracecompass-server &
+# @theia/cli not installed, so start the app directly.
+# Use Tutorial traces folder as workspace for easy access to traces
+node ./src-gen/backend/main.js --hostname 0.0.0.0 --port 4000 --plugins=local-dir:plugins /workspaces/TraceCompassTutorialTraces/

--- a/docker/theia-app-theia-ext/package.json
+++ b/docker/theia-app-theia-ext/package.json
@@ -32,7 +32,8 @@
     "start": "theia start",
     "watch": "theia build --watch",
     "clean": "echo 'Docker: Fake clean!!!'",
-    "test": "yarn --cwd ../../playwright-tests ui-tests"
+    "test": "yarn --cwd ../../playwright-tests ui-tests",
+    "test-demo": "echo \"TODO: Add tests\" && /bin/true"
   },
   "engines": {
     "yarn": ">=1.7.0 <2",

--- a/docker/theia-app-vscode-ext/package.json
+++ b/docker/theia-app-vscode-ext/package.json
@@ -42,6 +42,6 @@
   },
   "theiaPluginsDir": "plugins",
   "theiaPlugins": {
-      "vscode-trace-extension": "https://open-vsx.org/api/eclipse-cdt/vscode-trace-extension/0.2.6/file/eclipse-cdt.vscode-trace-extension-0.2.6.vsix"
+      "vscode-trace-extension": "https://open-vsx.org/api/eclipse-cdt/vscode-trace-extension/0.2.9/file/eclipse-cdt.vscode-trace-extension-0.2.9.vsix"
   }
 }

--- a/docker/theia-app-vscode-ext/package.json
+++ b/docker/theia-app-vscode-ext/package.json
@@ -34,7 +34,8 @@
     "start": "theia start --plugins=local-dir:plugins",
     "watch": "theia build --watch",
     "download:plugins": "theia download:plugins --rate-limit=15 --parallel=false --ignore-errors",
-    "test": "echo \"TODO: Add tests\" && /bin/true"
+    "test": "echo \"TODO: Add tests\" && /bin/true",
+    "test-demo": "echo \"TODO: Add tests\" && /bin/true"
   },
   "engines": {
     "yarn": ">=1.7.0 <2",


### PR DESCRIPTION
The goal is to extend the existing images to make "demo" images, that include a trace server and the tutorial traces. These "demo" versions of the images can be fired-up and used immediately to do some trace viewing.

To get started quickly, look at the [README](https://github.com/marcdumais-work/trace-viewer-examples/blob/4a0ce24c43ed08a1d28cd45ab05e19cc398b67e8/docker/theia-app-demo/README.md) under folder docker/theia-app-demo/

