### PR TITLE
[CI][workflows][images] Use node 20 by default

### DIFF
--- a/.github/workflows/docker-example.yml
+++ b/.github/workflows/docker-example.yml
@@ -21,7 +21,7 @@ jobs:
           - name: "tave"
             resources-folder: "theia-app-vscode-ext"
         os: [ubuntu-latest]
-        node-version: [18]
+        node-version: [20]
 
     steps:
     - uses: actions/checkout@v4

--- a/docker/Dockerfile-tate
+++ b/docker/Dockerfile-tate
@@ -1,4 +1,4 @@
-FROM node:18.20.4-bookworm-slim AS build
+FROM node:20.18.2-bookworm-slim AS build
 ARG RESOURCES
 
 RUN apt-get update && apt-get install -y \
@@ -25,7 +25,7 @@ RUN yarn && \
     yarn --production && \
     yarn cache clean
 
-FROM node:18.19.1-bookworm-slim
+FROM node:20.18.2-bookworm-slim 
 ARG RESOURCES
 
 COPY --from=build /app/tv /app/tv

--- a/docker/Dockerfile-tave
+++ b/docker/Dockerfile-tave
@@ -1,4 +1,4 @@
-FROM node:18.20.4-bookworm-slim AS build
+FROM node:20.18.2-bookworm-slim AS build
 ARG RESOURCES
 
 RUN apt-get update && apt-get install -y \
@@ -27,7 +27,7 @@ RUN yarn && \
     yarn --production && \
     yarn cache clean
 
-FROM node:18.19.1-bookworm-slim
+FROM node:20.18.2-bookworm-slim 
 ARG RESOURCES
 
 COPY --from=build /app/tv /app/tv

--- a/docker/theia-app-theia-ext/package.json
+++ b/docker/theia-app-theia-ext/package.json
@@ -37,7 +37,7 @@
   },
   "engines": {
     "yarn": ">=1.7.0 <2",
-    "node": ">=18 <21"
+    "node": ">=18 <23"
   },
   "resolutions": {
     

--- a/docker/theia-app-vscode-ext/package.json
+++ b/docker/theia-app-vscode-ext/package.json
@@ -39,7 +39,7 @@
   },
   "engines": {
     "yarn": ">=1.7.0 <2",
-    "node": ">=18 <21"
+    "node": ">=18 <23"
   },
   "theiaPluginsDir": "plugins",
   "theiaPlugins": {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/trace-viewer-examples/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Use base Docker images that bundle node 20 and modify example applications "engines.node" to require using at least node.js 18 to build.

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Verify that CI still passes.

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
